### PR TITLE
Allow to stream updates during diffing

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,22 @@ Build
 Tests
 -----
 
+All tests can be run at once:
+
     $ rebar3 do ct, proper, dialyzer
+
+To run more advanced/trickier PropEr tests, you can try to tweak the VM
+time options (`+T 9`), a thing rebar3 can't do:
+
+    $ rebar3 proper -n 1
+    ... compiler output to set up environment ...
+    
+    $ ERL_LIBS=_build/test/lib erl +T 9 -pa _build/test/lib/sdiff/test/
+    1> proper:module(prop_sync, [{numtests,1000}]).
+    .....
+
+This has a tendency to find a few timing bugs more easily, but runs
+quite a bit slower.
 
 Demo
 -----

--- a/README.md
+++ b/README.md
@@ -115,11 +115,12 @@ can avoid passing message through it to reach the client directly
 
 This is where all the complexity lies.
 The protocol is in multiple phases, and is triggered by a client demand,
-and requires synchronization with the server so that all trailing messages are
-avoided.
+and requires synchronization with the server so that updates are received
+in the right order.
 
-The server middleman will maintain a queue of pending updates during the
-diffing, to be replayed as soon as things are done.
+The server middleman will maintain a queue of keys relayed in updates during
+the diffing, and will remove them from the diff result (as the diff would
+now be outdated regarding these keys).
 
 Because the diffing action enabled by `merklet` is blocking and stateless,
 a fourth server process (DIFFER) is introduced:
@@ -158,7 +159,9 @@ a fourth server process (DIFFER) is introduced:
 
 1. The client is asked to diff
 2. The client process sends the tree to its middleman, making a copy of it
-3. The synchronous phase begins, letting all in-flight messages drain to the client
+3. The synchronous phase begins, letting all in-flight messages prior to the diffing
+   drain to the client. This isn't strictly necessary, but opens the door to some
+   protocol-specific optimizations.
 4. The differ grabs the tree from the SERVER
 5. Diffing starts, with the differ on the server asking for data on the merkle
    tree of the client, and the client answering back. This goes on for a while.
@@ -168,6 +171,9 @@ a fourth server process (DIFFER) is introduced:
 6. The diffing is done, a list of result is returned to the MIDDLEMAN, which
    uses the `ReadFun` value to replay results after closing the diff protocol
 7. The values in 6. being replayed.
+
+During the entire operations, regular updates can still be streamed to the client
+without interruption.
 
 Another subtlety is that while the `diff` is a PUSH operation from RANCH WORKER
 to MIDDLEMAN, all other reads from the socket are PULL-only with MIDDLEMAN asking
@@ -239,15 +245,14 @@ TODO
 -----
 
 - More Tests
+- have deletes delete entries that exist in property-based tests
 - tree snapshot functionality (for cheaper success/failure)
-- tree + dataset snapshot functionality (to re-sync trees too out of date?
-  maybe better as a side-protocol)
-- conditional updates on the client-side (so that failures are automatically
-  retried on the next repair)
 - Failure handling in sockets closing too often
 - Define the access function behaviour for clients and servers (lets people use
   other stuff than unauthenticated TCP for things)
-- use TCP_NODELAY only when diffing
-- have deletes delete entries that exist
-- allow for asynchronous update streams during diffing
+- use TCP_NODELAY only when diffing / evaluate impact
+- conditional updates on the client-side (so that failures are automatically
+  retried on the next repair)
+- tree + dataset snapshot functionality (to re-sync trees too out of date?
+  maybe better as a side-protocol)
 - and so on

--- a/test/model_client.erl
+++ b/test/model_client.erl
@@ -1,6 +1,6 @@
 -module(model_client).
 -define(MAGIC_KEY, <<"$$ THIS IS SPECIAL $$">>).
--export([start/0, write/2, ready/0, delete/1, diff/0, sync_diff/0,
+-export([start/0, write/2, ready/0, delete/1, sync_diff/0,
          wait_connected/0]).
 
 start() ->
@@ -22,12 +22,6 @@ ready() ->
 delete(K) ->
     ets:delete(client, K), % manual delete
     sdiff_client:delete(client, K).
-
-diff() ->
-    case sdiff_client:diff(client) of
-        async_diff -> async_diff;
-        already_diffing -> diff()
-    end.
 
 sync_diff() ->
     case sdiff_client:sync_diff(client) of

--- a/test/model_join.erl
+++ b/test/model_join.erl
@@ -65,12 +65,12 @@ stop(tcp) ->
 
 
 join() ->
-    %% Synchronize here. We do it by inserting a magic key with a unique
+    %% Synchronize a stream here. We do it by inserting a magic key with a unique
     %% value and waiting for it to come to the client, meaning everything in-
     %% between should be there.
-    %% This relies on a property by which a stream of updates is in order,
-    %% and interrupted by a diff sequence, which is currently an implementation
-    %% detail.
+    %% This relies on a property by which a stream of updates is in order.
+    %% However, because things aren't interrupted by diff sequences, little
+    %% this property only holds with synchronous diffs and not asynchronous ones.
     %% The other problem is that the connection process is asynchronous and can
     %% fail if it came too fast right after the first declaration of
     %% readiness. Because of this, we try to re-write the token value

--- a/test/prop_sync.erl
+++ b/test/prop_sync.erl
@@ -76,7 +76,6 @@ command(#state{server = {init, _}}) ->
 command(#state{clients = [{ready, _}], server = {ready, _}}) ->
     oneof([{call, ?SERVER, write, [key(), val()]},
            {call, ?SERVER, delete, [key()]},
-           {call, ?CLIENT, diff, []},
            {call, ?CLIENT, sync_diff, []},
            {call, ?BOTH, join, []}]).
 
@@ -119,17 +118,13 @@ next_state(S=#state{clients=Clients, server={SS, M}}, _V,
             S#state{server={SS, M#{K => V}}}
     end;
 %% Sync & Read
-next_state(S=#state{clients=[{CS,_}], server={_,M}}, _V,
-           {call, ?CLIENT, diff, []}) ->
-    %% gonna need a precond on both being ready
-    S#state{clients=[{CS,M}]};
 next_state(S=#state{clients=[{CS,_CM}], server={_,M}}, _V,
            {call, ?CLIENT, sync_diff, []}) ->
     %% gonna need a precond on both being ready
     S#state{clients=[{CS,M}]};
 next_state(State, _V, {call, ?BOTH, join, []}) ->
     %% this is a virtual call to just say "wait up!" and let
-    %% async postconditions sync up
+    %% async streams catch up.
     State.
 
 precondition(#state{clients=[{disconnected,_}], server={await,_}}, Call) ->
@@ -162,8 +157,6 @@ postcondition(_S, {call, _, write, [_K,_V]}, Result) ->
     Result =:= ok;
 postcondition(_S, {call, _, delete, [_K]}, Result) ->
     Result =:= ok;
-postcondition(_S, {call, _, diff, []}, Result) ->
-    Result =:= async_diff;
 postcondition(#state{clients=[{_,_}], server={_,S}}, {call, ?CLIENT, sync_diff, []},
               {done, Map}) ->
     Res = Map =:= S,
@@ -171,6 +164,10 @@ postcondition(#state{clients=[{_,_}], server={_,S}}, {call, ?CLIENT, sync_diff, 
     Res;
 postcondition(#state{clients=[{_,C}], server={_,S}}, {call, ?BOTH, join, []},
               {CliRes, SRes}) ->
+    %% This assumes that all diffs are synchronous. Without that, the two maps
+    %% may not be fully identical as the message used by model_join:join may
+    %% make it through before an async diff is done, breaking the expected
+    %% equivalence in the model.
     Res = C =:= CliRes andalso S =:= SRes,
     Res orelse ct:pal("join ~p =:= ~p~nandalso~n~p =:= ~p", [C, CliRes, S, SRes]),
     Res.


### PR DESCRIPTION
Rather than the serving interrupting all updates and then de-duping them
by key with the diff results and _then_ streaming it all at once, the
server relays the updates as they come in, and only stores the keys in
memory.

When the diff is done, it deduplicates following the usual mechanism and
only sends the differing entries that were _not_ modified during the
diff back to the client. This logically gives the same result set, but
without delaying in-flight data.

The client has been extended accordingly.
